### PR TITLE
chore: pin axios to 1.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\""
   },
   "dependencies": {
-    "axios": "^1.13.6",
+    "axios": "1.13.6",
     "chai": "^4.5.0",
     "form-data": "4.0.5",
     "mocha": "11.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,7 +327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.6":
+"axios@npm:1.13.6":
   version: 1.13.6
   resolution: "axios@npm:1.13.6"
   dependencies:
@@ -2679,7 +2679,7 @@ __metadata:
   resolution: "roku-client-sdk@workspace:."
   dependencies:
     "@rokucommunity/bslint": "npm:^0.8.38"
-    axios: "npm:^1.13.6"
+    axios: "npm:1.13.6"
     brighterscript: "npm:^0.70.3"
     chai: "npm:^4.5.0"
     form-data: "npm:4.0.5"


### PR DESCRIPTION
## Summary

- Pins axios from `^1.13.6` to `1.13.6`
- Avoids exposure to the supply chain attack reported in axios 1.14.1