### PR TITLE
fix: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postman-request/tough-cookie": "4.1.4",
     "lodash": "4.18.1",
     "picomatch": "4.0.4",
-    "brace-expansion": "5.0.5"
+    "brace-expansion": "5.0.5",
+    "follow-redirects": "1.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,13 +1114,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
+  checksum: 10/3fbe3d80b3b544c22705d837aa5d4a0d07a740d913534a2620b0a004c610af4148e3b58723536dd099aaa1c9d3a155964bde9665d6e5cb331460809a1fc572fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Pinned `follow-redirects` to 1.16.0 via yarn resolution to resolve medium severity vulnerability (alert #68)