### PR TITLE
fix: update actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: make bundle VERSION=${{ steps.prepare-release.outputs.next-release-tag }}
 
       - name: Upload package.zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: package-${{ steps.prepare-release.outputs.next-release-tag }}.zip


### PR DESCRIPTION
GitHub deprecated and began auto-failing workflows that reference `actions/upload-artifact@v3`. Updates the release workflow to use `v4`.

Failed run: https://github.com/DevCycleHQ/roku-client-sdk/actions/runs/25077755064/job/73474831608