### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "picomatch": "4.0.4",
     "brace-expansion": "5.0.5",
     "follow-redirects": "1.16.0",
+    "socks": "2.8.9",
     "ip-address": "10.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\""
   },
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "chai": "^4.5.0",
     "form-data": "4.0.5",
     "mocha": "11.7.5",
@@ -30,6 +30,7 @@
     "lodash": "4.18.1",
     "picomatch": "4.0.4",
     "brace-expansion": "5.0.5",
-    "follow-redirects": "1.16.0"
+    "follow-redirects": "1.16.0",
+    "ip-address": ">=10.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "picomatch": "4.0.4",
     "brace-expansion": "5.0.5",
     "follow-redirects": "1.16.0",
-    "ip-address": ">=10.1.1"
+    "ip-address": "10.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postman-request/tough-cookie": "4.1.4",
     "lodash": "4.18.1",
     "picomatch": "4.0.4",
-    "brace-expansion": "5.0.5",
+    "brace-expansion": "5.0.6",
     "follow-redirects": "1.16.0",
     "socks": "2.8.9",
     "ip-address": "10.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2829,13 +2829,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.8.3":
-  version: 2.8.3
-  resolution: "socks@npm:2.8.3"
+"socks@npm:2.8.9":
+  version: 2.8.9
+  resolution: "socks@npm:2.8.9"
   dependencies:
-    ip-address: "npm:^9.0.5"
+    ip-address: "npm:^10.1.1"
     smart-buffer: "npm:^4.2.0"
-  checksum: 10/ffcb622c22481dfcd7589aae71fbfd71ca34334064d181df64bf8b7feaeee19706aba4cffd1de35cc7bbaeeaa0af96be2d7f40fcbc7bc0ab69533a7ae9ffc4fb
+  checksum: 10/8675e6b023faeaa5c2511664b106fd21f5d5ecb403584412e0efae58a76e0c0661c0c18ca340988f6cb398232308dae85fb710f847c9c6e0a6af33b07e4cd33a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,7 +1519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:>=10.1.1":
+"ip-address@npm:10.2.0":
   version: 10.2.0
   resolution: "ip-address@npm:10.2.0"
   checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,12 +368,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,14 +327,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
+  checksum: 10/eebbd8cb777316d4252cd994a06ec9fb956ef519214a62dab6c5443ae8b753b5116e9a770502316789e6cdef1101e6aae53b6936d6a3791b2d66d75f4d7d2462
   languageName: node
   linkType: hard
 
@@ -1519,13 +1519,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: "npm:1.1.0"
-    sprintf-js: "npm:^1.1.3"
-  checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
+"ip-address@npm:>=10.1.1":
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1
   languageName: node
   linkType: hard
 
@@ -1668,13 +1665,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 10/bebe7ae829bbd586ce8cbe83501dd8cb8c282c8902a8aeeed0a073a89dc37e8103b1244f3c6acd60278bcbfe12d93a3f83c9ac396868a3b3bbc3c5e5e3b648ef
   languageName: node
   linkType: hard
 
@@ -2639,7 +2629,7 @@ __metadata:
   resolution: "roku-client-sdk@workspace:."
   dependencies:
     "@rokucommunity/bslint": "npm:^0.8.38"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
     brighterscript: "npm:^0.70.3"
     chai: "npm:^4.5.0"
     form-data: "npm:4.0.5"
@@ -2853,13 +2843,6 @@ __metadata:
   version: 0.7.4
   resolution: "source-map@npm:0.7.4"
   checksum: 10/a0f7c9b797eda93139842fd28648e868a9a03ea0ad0d9fa6602a0c1f17b7fb6a7dcca00c144476cccaeaae5042e99a285723b1a201e844ad67221bf5d428f1dc
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: 10/e7587128c423f7e43cc625fe2f87e6affdf5ca51c1cc468e910d8aaca46bb44a7fbcfa552f787b1d3987f7043aeb4527d1b99559e6621e01b42b3f45e5a24cbb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolved 22 open Dependabot security alerts by bumping vulnerable dependencies

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #71–#80, #82–#90 | `axios` | HIGH/MEDIUM/LOW | Bumped direct dependency to 1.15.2 |
| #81, #83, #85, #87, #89 | `axios` | HIGH/MEDIUM/LOW | Same fix via `package.json` manifest |
| #70 | `ip-address` | MEDIUM | Pinned resolution to 10.2.0 |
| #91 | `brace-expansion` | MEDIUM | Bumped resolution from 5.0.5 to 5.0.6 |

**Details:**
- Bumped `axios` from 1.15.0 to 1.15.2 to resolve multiple high/medium/low severity vulnerabilities (alerts #71–#90): Prototype Pollution Gadgets, Header Injection, HTTP adapter streamed response/request bypasses, CRLF Injection, Prototype Pollution in parseReviver, SSRF via no\_proxy bypass, and Null Byte Injection
- Added `socks` resolution to 2.8.9 (which natively requires `ip-address@^10.1.1`) and pinned `ip-address` to 10.2.0 to fix XSS in Address6 HTML-emitting methods (alert #70, medium severity). Upgrading socks to 2.8.9 removes the incompatibility between the forced ip-address v10 and socks@2.8.3's declared `ip-address@^9.0.5` dependency.
- Bumped `brace-expansion` resolution from 5.0.5 to 5.0.6 to fix Large numeric range DoS protection bypass (alert #91, medium severity)