### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\""
   },
   "dependencies": {
-    "axios": "1.15.2",
+    "axios": "1.16.0",
     "chai": "^4.5.0",
     "form-data": "4.0.5",
     "mocha": "11.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,14 +327,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.2":
-  version: 1.15.2
-  resolution: "axios@npm:1.15.2"
+"axios@npm:1.16.0":
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/eebbd8cb777316d4252cd994a06ec9fb956ef519214a62dab6c5443ae8b753b5116e9a770502316789e6cdef1101e6aae53b6936d6a3791b2d66d75f4d7d2462
+  checksum: 10/cf8b521ff732c21550b38c8739aef556ea5e14b268468bb89e4307416ab262b462e582474e810963a3d61c2392ab47ad35c11d05eff027de7c97113bc7411623
   languageName: node
   linkType: hard
 
@@ -2629,7 +2629,7 @@ __metadata:
   resolution: "roku-client-sdk@workspace:."
   dependencies:
     "@rokucommunity/bslint": "npm:^0.8.38"
-    axios: "npm:1.15.2"
+    axios: "npm:1.16.0"
     brighterscript: "npm:^0.70.3"
     chai: "npm:^4.5.0"
     form-data: "npm:4.0.5"


### PR DESCRIPTION
## Summary

- Bumped `axios` 1.15.2 -> 1.16.0 to resolve 10 high/low severity Dependabot alerts (DoS / data integrity advisories affecting axios < 1.16.0)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #93-#102 | `axios` | **high** / low | Bumped direct dependency to 1.16.0 |

## Unresolvable

- **#92 `uuid`** (medium, CVE-2026-41907): uuid@3.4.0 is pulled in transitively via `roku-deploy` -> `postman-request` (dev tooling), which requires the v3-era `require('uuid/v4')` subpath. The patched version (>= 11.1.1) removed that subpath export, so forcing it breaks postman-request at runtime (`ERR_PACKAGE_PATH_NOT_EXPORTED`). No patched version is compatible with the `^3.3.2` consumer constraint. The vulnerable code path (bounds check in v3/v5/v6 when `buf` is provided) is also not exercised: postman-request calls `uuid/v4()` with no arguments.