### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "axios": "1.16.0",
     "chai": "^4.5.0",
-    "form-data": "4.0.5",
+    "form-data": "4.0.6",
     "mocha": "11.7.5",
     "nock": "13.5.6"
   },
@@ -25,13 +25,15 @@
   "resolutions": {
     "serialize-javascript": "7.0.5",
     "diff": "8.0.3",
-    "postman-request/form-data": "2.5.4",
+    "postman-request/form-data": "2.5.6",
+    "@types/request/form-data": "2.5.6",
     "postman-request/tough-cookie": "4.1.4",
     "lodash": "4.18.1",
     "picomatch": "4.0.4",
     "brace-expansion": "5.0.6",
     "follow-redirects": "1.16.0",
     "socks": "2.8.9",
-    "ip-address": "10.2.0"
+    "ip-address": "10.2.0",
+    "tar": "7.5.16"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,44 +1141,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:2.5.4":
-  version: 2.5.4
-  resolution: "form-data@npm:2.5.4"
+"form-data@npm:2.5.6":
+  version: 2.5.6
+  resolution: "form-data@npm:2.5.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    has-own: "npm:^1.0.1"
+    hasown: "npm:^2.0.4"
     mime-types: "npm:^2.1.35"
     safe-buffer: "npm:^5.2.1"
-  checksum: 10/30f40ac68f9f677f1e6451ec4a6f32a64fb6cb7c6cec60599375a1b25ee3e14038f6f5c99ea4390577482dc199239a09240dc892b01045992b052836d9e190fb
+  checksum: 10/7b2afddf638125b6d22936a1f642e88887b279504510e3f56be6dc90bea35cb8124fe6ecc75032e92264b5ebfbd183d0992307588c782eaa88d1bed76381ad6b
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.5, form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+"form-data@npm:4.0.6, form-data@npm:^4.0.5":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^2.5.5":
-  version: 2.5.5
-  resolution: "form-data@npm:2.5.5"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
+    hasown: "npm:^2.0.4"
     mime-types: "npm:^2.1.35"
-    safe-buffer: "npm:^5.2.1"
-  checksum: 10/4b6a8d07bb67089da41048e734215f68317a8e29dd5385a972bf5c458a023313c69d3b5d6b8baafbb7f808fa9881e0e2e030ffe61e096b3ddc894c516401271d
+  checksum: 10/de6614c8537c92fa5fa3ee7e827758f98f5a9c033f348b7de81855ef36e5cb867e75d9f405d9483ab8d724a4a20d4e79926a299fa8dbba38f530eb659f0884e4
   languageName: node
   linkType: hard
 
@@ -1396,13 +1382,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-own@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "has-own@npm:1.0.1"
-  checksum: 10/3893dd749c56fbda5c8a6277cf627d5ec8de2094fd8beb2cb17d492c1773e5826d092512714b94ffa11fb8c2f5c31106adf6dd60d53680c2846246addff94338
-  languageName: node
-  linkType: hard
-
 "has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
@@ -1425,6 +1404,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/13823863ae48161068b4c51606a3128451c66f14545a5169d667fe9fca168dcd38c27570c7a299e32ef844b8da3d55def7fe88602f8970d4311fb543ee88001a
   languageName: node
   linkType: hard
 
@@ -1951,7 +1939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.35, mime-types@npm:~2.1.19":
+"mime-types@npm:^2.1.35, mime-types@npm:~2.1.19":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -2632,7 +2620,7 @@ __metadata:
     axios: "npm:1.16.0"
     brighterscript: "npm:^0.70.3"
     chai: "npm:^4.5.0"
-    form-data: "npm:4.0.5"
+    form-data: "npm:4.0.6"
     lint-staged: "npm:^15.5.2"
     mocha: "npm:11.7.5"
     nock: "npm:13.5.6"
@@ -2993,16 +2981,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.4":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:7.5.16":
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/fb2e77ee858a73936c68e066f4a602d428d6f812e6da0cc1e14a41f99498e4f7fd3535e355fa15157240a5538aa416026cfa6306bb0d1d1c1abf314b1f878e9a
+  checksum: 10/fafa22efceb9f056bf29ddc47d9bd90bb82fe3ce57b8d1242fc45771251741964cebba69d4e14a24fd1643f3c7f68478e945a19def534703cf370c2d9dca2e09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolved 4 open Dependabot security alerts by bumping vulnerable dependencies

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #106 | `form-data` | **high** | Bumped direct dep from 4.0.5 to 4.0.6 in package.json |
| #107 | `form-data` | **high** | Resolved via form-data 4.0.6 bump (yarn.lock 4.x instance) |
| #105 | `form-data` | **high** | Updated `postman-request/form-data` and `@types/request/form-data` resolutions to 2.5.6 |
| #108 | `tar` | **medium** | Added `tar: 7.5.16` resolution to override transitive 7.5.11 from node-gyp |

## Unresolvable Alert

- **Alert #92** (`uuid` medium, CVE-2026-41907): `postman-request` requires `uuid@^3.3.2` using the legacy `uuid/v4` subpath API, which was removed in uuid v7+. There is no 3.x patch release; the fix requires uuid 11.1.1+ which is a breaking API change that postman-request cannot accept. This alert cannot be resolved without replacing postman-request.