### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "follow-redirects": "1.16.0",
     "socks": "2.8.9",
     "ip-address": "10.2.0",
-    "tar": "7.5.16",
-    "js-yaml": "4.2.0",
+    "tar": "7.5.19",
+    "js-yaml": "4.3.0",
     "uuid": "11.1.1",
     "roku-deploy": "3.18.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,14 +1436,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/51de2067a2b44b07ba5206132e56005f8b568ff279bb4d2f645068958c56fa4827d40a6841c983234671fa0a134bf094d0b0717873c2a3d319185297af145a6d
+  checksum: 10/2bcec3a8118d7f744badeb04e14366578d234a736f353d41fe35d2305e4ce2409a8e041d277f07cd6bbc8aaa12128d650a68ce43247072519bede20962d2126f
   languageName: node
   linkType: hard
 
@@ -2621,16 +2621,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.16":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+"tar@npm:7.5.19":
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/fafa22efceb9f056bf29ddc47d9bd90bb82fe3ce57b8d1242fc45771251741964cebba69d4e14a24fd1643f3c7f68478e945a19def534703cf370c2d9dca2e09
+  checksum: 10/0b06a0917fe68a4dff361e147db30fd67ae2ee85ab2863d62046a6ccef46f0d1906eed20f92277a436300eaaa0e3cd31d8763d7f02fa389f41d7966e58388db8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolved 5 open Dependabot security alerts by bumping vulnerable transitive dependencies via Yarn resolutions

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #127 | `tar` | **critical** | Bumped resolution to 7.5.19 (CVE-2026-59873: Decompression/parse DoS via unlimited input) |
| #126 | `tar` | **high** | Covered by 7.5.19 resolution (patched at 7.5.18) |
| #124 | `js-yaml` | **high** | Bumped resolution to 4.3.0 (CVE-2026-59869: YAML merge-key chains quadratic CPU) |
| #128 | `tar` | **medium** | Covered by 7.5.19 resolution (patched at 7.5.18) |
| #125 | `tar` | **medium** | Covered by 7.5.19 resolution (patched at 7.5.17) |

Both packages are transitive dependencies resolved via Yarn `resolutions` in `package.json`.