### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "follow-redirects": "1.16.0",
     "socks": "2.8.9",
     "ip-address": "10.2.0",
-    "tar": "7.5.19",
+    "tar": "7.5.21",
     "js-yaml": "4.3.0",
     "uuid": "11.1.1",
     "roku-deploy": "3.18.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,16 +2621,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.19":
-  version: 7.5.19
-  resolution: "tar@npm:7.5.19"
+"tar@npm:7.5.21":
+  version: 7.5.21
+  resolution: "tar@npm:7.5.21"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/0b06a0917fe68a4dff361e147db30fd67ae2ee85ab2863d62046a6ccef46f0d1906eed20f92277a436300eaaa0e3cd31d8763d7f02fa389f41d7966e58388db8
+  checksum: 10/a1b7dcee15e4f7dbef7f07c3cf0fe946248efabd1cb029b54c698d817dfc2876c75bcaa164a12dd21191e385759ce3e37fea562cf4aabaa00984ef9ed3c48d17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `tar` to 7.5.21 to resolve medium severity vulnerability (alert #129)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #129 | `tar` | **medium** | Bumped to 7.5.21 via resolutions override |

**Vulnerability:** node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection (CVE advisory, vulnerable range <= 7.5.20)