### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20.10.0"
           cache: "yarn"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out the repo with credentials that can bypass branch protection, and fetch git history instead of just latest commit
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
         run: make bundle VERSION=${{ steps.prepare-release.outputs.next-release-tag }}
 
       - name: Upload package.zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package
           path: package-${{ steps.prepare-release.outputs.next-release-tag }}.zip


### PR DESCRIPTION
## Summary

- Update GitHub Actions and custom action dependencies to Node 24-compatible releases.
- Update nested dependencies in composite and custom actions.
- Retain actions without an available Node 24 release.